### PR TITLE
Code Review \O/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 A simple program used to search through your installed programs and tell you what you can run
 
 ### Usage & Installation
-You must have the package `python3` and `git` installed 
-```
+You must have the packages `python3` and `git` installed. Then run the following in a terminal:
+
+```bash
 git clone https://github.com/crutchcorn/pyappsch.git
 cd pyappsch
 python3 textapplauncher.py

--- a/checkinput.py
+++ b/checkinput.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 def checkinput(userinput):
-	i=1
+	i = 1

--- a/checkinput.py
+++ b/checkinput.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 def checkinput(userinput):
-	i = 1
+    i = 1

--- a/textapplauncher.py
+++ b/textapplauncher.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # Set up
-import os
-import re
-import sys
+from os import listdir, path, remove
+from re import compile as recomp
+from sys import stdout
 from subprocess import call
 from confirmnumber import confirmNumber
 from checkinput import checkinput
@@ -13,12 +13,12 @@ pexec = ""
 
 # Add to CheckInput
 def addToCheckInput(location):
-	for filename in os.listdir(location):
+	for filename in listdir(location):
 		appname = open(location + filename)
 		for line in appname:
 			if "Name=" in line:
 				name = line.rstrip().replace('Name=', '')
-				regex = re.compile('[^a-zA-Z]')
+				regex = recomp('[^a-zA-Z]')
 				nospacename = regex.sub('', name)
 			if "Exec=" in line:
 					pexec = line.rstrip().replace('Exec=', '')
@@ -37,12 +37,12 @@ def addToCheckInput(location):
 
 # This allows the second time of checkinput.py to be normal
 def generatechecknumbergen(location):
-	for filename in os.listdir(location):
+	for filename in listdir(location):
 		appname = open(location + filename)
 		for line in appname:
 			if "Name=" in line:
 				name = line.rstrip().replace('Name=', '')
-				regex = re.compile('[^a-zA-Z]')
+				regex = recomp('[^a-zA-Z]')
 				nospacename = regex.sub('', name)
 			if "Exec=" in line:
 					pexec = line.rstrip().replace('Exec=', '')
@@ -54,7 +54,7 @@ def generatechecknumbergen(location):
 			myfile.write(r"		print('\n')")
 			myfile.write("\n")
 
-home = os.path.expanduser("~")
+home = path.expanduser("~")
 addToCheckInput("/usr/share/applications/")
 addToCheckInput(home+"/.local/share/applications/")
 
@@ -76,10 +76,10 @@ generatechecknumbergen(home+"/.local/share/applications/")
 
 # Change checkinput.py to be output of checkinput(userinput)
 # THIS IS THE PROBLEM!!!!
-sys.stdout = open('checkinput.py', 'w')
+stdout = open('checkinput.py', 'w')
 checknumbergen(userinput)
-sys.stdout.close()
-sys.stdout = open("/dev/stdout", "w")
+stdout.close()
+stdout = open("/dev/stdout", "w")
 
 # Removes blank lines
 clean_lines = []
@@ -111,8 +111,8 @@ userNumber = str(input("Pick a number to launch the program: "))
 confirmNumber(userNumber)
 
 # Clear file to default
-os.remove("checknumbergen.py")
-os.remove("confirmnumber.py")
+remove("checknumbergen.py")
+remove("confirmnumber.py")
 open('checkinput.py', 'w').close()
 with open("checkinput.py", "a") as myfile:
 	myfile.write("#!/usr/bin/env python3\n")

--- a/textapplauncher.py
+++ b/textapplauncher.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+from subprocess import call
 from confirmnumber import confirmNumber
 from checkinput import checkinput
 from checknumbergen import checknumbergen
@@ -60,7 +61,7 @@ addToCheckInput(home+"/.local/share/applications/")
 userinput = input("These are the programs you can launch. Pick one: ")
 
 # Clears the screen, making the visibility of the new results much clearer
-os.system('clear')
+call(["clear"])
 
 print("These are some of the programs that you can use:\n")
 

--- a/textapplauncher.py
+++ b/textapplauncher.py
@@ -13,46 +13,46 @@ pexec = ""
 
 # Add to CheckInput
 def addToCheckInput(location):
-	for filename in listdir(location):
-		appname = open(location + filename)
-		for line in appname:
-			if "Name=" in line:
-				name = line.rstrip().replace('Name=', '')
-				regex = recomp('[^a-zA-Z]')
-				nospacename = regex.sub('', name)
-			if "Exec=" in line:
-					pexec = line.rstrip().replace('Exec=', '')
-		# Create function
-		with open("checkinput.py", "a") as myfile:
-			myfile.write('	'+nospacename+'="'+name+'"\n')
-			myfile.write("	if userinput in "+nospacename+":\n")
-			myfile.write("		print('Program number: ', i)\n")
-			myfile.write("		print('Program name: "+name+"')\n")
-			myfile.write("		print('Exec command: "+pexec+"')\n")
-			myfile.write("		i=i+1\n")
-			myfile.write(r"		print('\n')")
-			myfile.write("\n")
-		print(name)
+    for filename in listdir(location):
+        appname = open(location + filename)
+        for line in appname:
+            if "Name=" in line:
+                name = line.rstrip().replace('Name=', '')
+                regex = recomp('[^a-zA-Z]')
+                nospacename = regex.sub('', name)
+            if "Exec=" in line:
+                    pexec = line.rstrip().replace('Exec=', '')
+        # Create function
+        with open("checkinput.py", "a") as myfile:
+            myfile.write('    '+nospacename+'="'+name+'"\n')
+            myfile.write("    if userinput in "+nospacename+":\n")
+            myfile.write("        print('Program number: ', i)\n")
+            myfile.write("        print('Program name: "+name+"')\n")
+            myfile.write("        print('Exec command: "+pexec+"')\n")
+            myfile.write("        i=i+1\n")
+            myfile.write(r"        print('\n')")
+            myfile.write("\n")
+        print(name)
 
 
 # This allows the second time of checkinput.py to be normal
 def generatechecknumbergen(location):
-	for filename in listdir(location):
-		appname = open(location + filename)
-		for line in appname:
-			if "Name=" in line:
-				name = line.rstrip().replace('Name=', '')
-				regex = recomp('[^a-zA-Z]')
-				nospacename = regex.sub('', name)
-			if "Exec=" in line:
-					pexec = line.rstrip().replace('Exec=', '')
-		# Create function
-		with open("checknumbergen.py", "a") as myfile:
-			myfile.write('	'+nospacename+'="'+name+'"\n')
-			myfile.write("	if userinput in "+nospacename+":\n")
-			myfile.write("		print('"+pexec+"')\n")
-			myfile.write(r"		print('\n')")
-			myfile.write("\n")
+    for filename in listdir(location):
+        appname = open(location + filename)
+        for line in appname:
+            if "Name=" in line:
+                name = line.rstrip().replace('Name=', '')
+                regex = recomp('[^a-zA-Z]')
+                nospacename = regex.sub('', name)
+            if "Exec=" in line:
+                    pexec = line.rstrip().replace('Exec=', '')
+        # Create function
+        with open("checknumbergen.py", "a") as myfile:
+            myfile.write('    '+nospacename+'="'+name+'"\n')
+            myfile.write("    if userinput in "+nospacename+":\n")
+            myfile.write("        print('"+pexec+"')\n")
+            myfile.write(r"        print('\n')")
+            myfile.write("\n")
 
 home = path.expanduser("~")
 addToCheckInput("/usr/share/applications/")
@@ -70,7 +70,7 @@ checkinput(userinput)
 
 # Generates checknumbergen.py
 with open("checknumbergen.py", "a") as myfile:
-	myfile.write('def checknumbergen(userinput):\n')
+    myfile.write('def checknumbergen(userinput):\n')
 generatechecknumbergen("/usr/share/applications/")
 generatechecknumbergen(home+"/.local/share/applications/")
 
@@ -84,28 +84,28 @@ stdout = open("/dev/stdout", "w")
 # Removes blank lines
 clean_lines = []
 with open("checkinput.py", "r") as f:
-	lines = f.readlines()
-	clean_lines = [l.strip() for l in lines if l.strip()]
+    lines = f.readlines()
+    clean_lines = [l.strip() for l in lines if l.strip()]
 with open("checkinput.py", "w") as f:
-	f.writelines('\n'.join(clean_lines))
+    f.writelines('\n'.join(clean_lines))
 
 # Closes checknumbergen.py for later use
 open('checknumbergen.py', 'w').close()
 
 with open("confirmnumber.py", "a") as myfile:
-	myfile.write("#!/usr/bin/env python3\n")
-	myfile.write("from subprocess import call\n")
-	myfile.write("def confirmNumber(userNumber):\n")
+    myfile.write("#!/usr/bin/env python3\n")
+    myfile.write("from subprocess import call\n")
+    myfile.write("def confirmNumber(userNumber):\n")
 
 numbercount = 1
 with open("checkinput.py", "r") as checkinp:
-	checkinp = checkinp.read().splitlines()
-	for line in checkinp:
-		line = line
-		with open("confirmnumber.py", "a") as checknum:
-			checknum.write('	if userNumber=="'+str(numbercount)+'":\n')
-			checknum.write('		return_code = call("'+line+'", shell=True)\n')
-		numbercount = numbercount + 1
+    checkinp = checkinp.read().splitlines()
+    for line in checkinp:
+        line = line
+        with open("confirmnumber.py", "a") as checknum:
+            checknum.write('    if userNumber=="'+str(numbercount)+'":\n')
+            checknum.write('        return_code = call("'+line+'", shell=True)\n')
+        numbercount = numbercount + 1
 
 userNumber = str(input("Pick a number to launch the program: "))
 confirmNumber(userNumber)
@@ -115,6 +115,6 @@ remove("checknumbergen.py")
 remove("confirmnumber.py")
 open('checkinput.py', 'w').close()
 with open("checkinput.py", "a") as myfile:
-	myfile.write("#!/usr/bin/env python3\n")
-	myfile.write("def checkinput(userinput):\n")
-	myfile.write("	i=1\n")
+    myfile.write("#!/usr/bin/env python3\n")
+    myfile.write("def checkinput(userinput):\n")
+    myfile.write("    i=1\n")

--- a/textapplauncher.py
+++ b/textapplauncher.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
 # Set up
-import os	
+import os
 import re
 import sys
-name=""
-pexec=""
+from confirmnumber import confirmNumber
+from checkinput import checkinput
+from checknumbergen import checknumbergen
+name = ""
+pexec = ""
+
 
 # Add to CheckInput
 def addToCheckInput(location):
 	for filename in os.listdir(location):
-		appname=open(location+filename) 
+		appname = open(location + filename)
 		for line in appname:
 			if "Name=" in line:
-				name=line.rstrip().replace('Name=','')
+				name = line.rstrip().replace('Name=', '')
 				regex = re.compile('[^a-zA-Z]')
-				nospacename=regex.sub('', name)
+				nospacename = regex.sub('', name)
 			if "Exec=" in line:
-					pexec=line.rstrip().replace('Exec=','')
+					pexec = line.rstrip().replace('Exec=', '')
 		# Create function
 		with open("checkinput.py", "a") as myfile:
 			myfile.write('	'+nospacename+'="'+name+'"\n')
@@ -29,17 +33,18 @@ def addToCheckInput(location):
 			myfile.write("\n")
 		print(name)
 
+
 # This allows the second time of checkinput.py to be normal
 def generatechecknumbergen(location):
 	for filename in os.listdir(location):
-		appname=open(location+filename) 
+		appname = open(location + filename)
 		for line in appname:
 			if "Name=" in line:
-				name=line.rstrip().replace('Name=','')
+				name = line.rstrip().replace('Name=', '')
 				regex = re.compile('[^a-zA-Z]')
-				nospacename=regex.sub('', name)
+				nospacename = regex.sub('', name)
 			if "Exec=" in line:
-					pexec=line.rstrip().replace('Exec=','')
+					pexec = line.rstrip().replace('Exec=', '')
 		# Create function
 		with open("checknumbergen.py", "a") as myfile:
 			myfile.write('	'+nospacename+'="'+name+'"\n')
@@ -52,10 +57,7 @@ home = os.path.expanduser("~")
 addToCheckInput("/usr/share/applications/")
 addToCheckInput(home+"/.local/share/applications/")
 
-# Import function
-from checkinput import checkinput
-
-userinput=input("These are the programs you can launch. Pick one: ")
+userinput = input("These are the programs you can launch. Pick one: ")
 
 # Clears the screen, making the visibility of the new results much clearer
 os.system('clear')
@@ -70,10 +72,9 @@ with open("checknumbergen.py", "a") as myfile:
 	myfile.write('def checknumbergen(userinput):\n')
 generatechecknumbergen("/usr/share/applications/")
 generatechecknumbergen(home+"/.local/share/applications/")
-from checknumbergen import checknumbergen
 
 # Change checkinput.py to be output of checkinput(userinput)
-### THIS IS THE PROBLEM!!!!
+# THIS IS THE PROBLEM!!!!
 sys.stdout = open('checkinput.py', 'w')
 checknumbergen(userinput)
 sys.stdout.close()
@@ -87,7 +88,7 @@ with open("checkinput.py", "r") as f:
 with open("checkinput.py", "w") as f:
 	f.writelines('\n'.join(clean_lines))
 
-# Closes checknumbergen.py for later use 
+# Closes checknumbergen.py for later use
 open('checknumbergen.py', 'w').close()
 
 with open("confirmnumber.py", "a") as myfile:
@@ -95,22 +96,21 @@ with open("confirmnumber.py", "a") as myfile:
 	myfile.write("from subprocess import call\n")
 	myfile.write("def confirmNumber(userNumber):\n")
 
-numbercount=1
+numbercount = 1
 with open("checkinput.py", "r") as checkinp:
-	checkinp=checkinp.read().splitlines() 
+	checkinp = checkinp.read().splitlines()
 	for line in checkinp:
-		line=line
+		line = line
 		with open("confirmnumber.py", "a") as checknum:
 			checknum.write('	if userNumber=="'+str(numbercount)+'":\n')
 			checknum.write('		return_code = call("'+line+'", shell=True)\n')
-		numbercount=numbercount+1
+		numbercount = numbercount + 1
 
-from confirmnumber import confirmNumber
-userNumber=str(input("Pick a number to launch the program: "))
+userNumber = str(input("Pick a number to launch the program: "))
 confirmNumber(userNumber)
 
 # Clear file to default
-os.remove("checknumbergen.py") 
+os.remove("checknumbergen.py")
 os.remove("confirmnumber.py")
 open('checkinput.py', 'w').close()
 with open("checkinput.py", "a") as myfile:

--- a/textapplauncher.py
+++ b/textapplauncher.py
@@ -4,9 +4,6 @@ from os import listdir, path, remove
 from re import compile as recomp
 from sys import stdout
 from subprocess import call
-from confirmnumber import confirmNumber
-from checkinput import checkinput
-from checknumbergen import checknumbergen
 name = ""
 pexec = ""
 
@@ -57,6 +54,7 @@ def generatechecknumbergen(location):
 home = path.expanduser("~")
 addToCheckInput("/usr/share/applications/")
 addToCheckInput(home+"/.local/share/applications/")
+from checkinput import checkinput
 
 userinput = input("These are the programs you can launch. Pick one: ")
 
@@ -73,6 +71,7 @@ with open("checknumbergen.py", "a") as myfile:
     myfile.write('def checknumbergen(userinput):\n')
 generatechecknumbergen("/usr/share/applications/")
 generatechecknumbergen(home+"/.local/share/applications/")
+from checknumbergen import checknumbergen
 
 # Change checkinput.py to be output of checkinput(userinput)
 # THIS IS THE PROBLEM!!!!
@@ -107,6 +106,7 @@ with open("checkinput.py", "r") as checkinp:
             checknum.write('        return_code = call("'+line+'", shell=True)\n')
         numbercount = numbercount + 1
 
+from confirmnumber import confirmNumber
 userNumber = str(input("Pick a number to launch the program: "))
 confirmNumber(userNumber)
 


### PR DESCRIPTION
Saw you wanted a review on Google+, so here on is! This is split into 5 parts:
1. [Minor README adjustments](https://github.com/Foggalong/pyappsch/commit/a5049428de46f63d0798f70dbf4de302ff485cd4)
   - Small grammatical error
   - Added syntax highlighting for terminal input
2. [Ad-hears to the PEP8 style guide](https://github.com/Foggalong/pyappsch/commit/d9802f02dac356a2722aafd81c2c4c285b305d36). If you've not seen it before I'd highly recommend you give it a [look over](https://www.python.org/dev/peps/pep-0008/) - it just details the best practices for writing Python code. Noticeable changes include:
   - No trailing spaces
   - Spaces around operators (e.g. `i = 1` not `i=1`)
   - Double newlines before defining functions
   - Spaces after commas (e.g, `x, y` not `x,y`)
   - Module imports have to happen at the top of the file
3. [Removing the deprecated `os.system` function](https://github.com/Foggalong/pyappsch/commit/596b9d60dcb5f04fd0491bd755acb5b47a29dede). You can read [the docs](https://docs.python.org/2/library/subprocess.html#replacing-older-functions-with-the-subprocess-module) for more information as to why, but basically you now have to use `subprocess.call` instead.
4. [Cleaned up imports](https://github.com/Foggalong/pyappsch/commit/a3535da0c5b1e9a4c6942c4696c4813f504e1131). Generally it's better to only import the functions you need, rather than the whole module. Note the `from re import compile as recomp` is to avoid a function naming conflict with the default `compile()`.
5. Probably one of the more controversial parts of the PEP8 is that it says you should be using [spaces rather than tabs](https://github.com/Foggalong/pyappsch/commit/4c6c80f682a317685a6d192aa05928cae641815d). This commit makes that switch.
